### PR TITLE
Re-setting the image cache in _repaint method to force showing the co…

### DIFF
--- a/lib/src/page.dart
+++ b/lib/src/page.dart
@@ -28,6 +28,7 @@ class _PDFPageState extends State<PDFPage> {
   }
 
   _repaint() {
+    imageCache.clear();
     provider = FileImage(File(widget.imgPath));
     final resolver = provider.resolve(createLocalImageConfiguration(context));
     resolver.addListener((imgInfo, alreadyPainted) {


### PR DESCRIPTION
I suggest the following hot-fix for the problem, that the image cache seems to lead to the problem on iOS, that the PFD view always shows the first page of the previous document when loading a new PDF file. It's not an optimal solution, but it works on iOS as well as on Android devices.