### PR TITLE
Safely update _isLoading state

### DIFF
--- a/lib/src/viewer.dart
+++ b/lib/src/viewer.dart
@@ -55,16 +55,16 @@ class _PDFViewerState extends State<PDFViewer> {
   }
 
   _loadPage() async {
-    setState(() {
-      _isLoading = true;
-    });
+    setState(() => _isLoading = true);
+    
     if (_oldPage == 0) {
       _page = await widget.document.get(page: _pageNumber);
-      setState(() => _isLoading = false);
     } else if (_oldPage != _pageNumber) {
       _oldPage = _pageNumber;
-      setState(() => _isLoading = true);
       _page = await widget.document.get(page: _pageNumber);
+    }
+    
+    if(this.mounted) {
       setState(() => _isLoading = false);
     }
   }


### PR DESCRIPTION
Because `_loadPage` is called within lifecycle methods (didChangeDependencies, didUpdateWidget) and it is an async method, there is a possibility that it will execute `_loadPage` and then unmount before the `setState` methods after the `await` calls have been executed. When `setState` is called on an unmounted widget, an error is thrown and the app crashes.

This PR checks if the component is still mounted before it calls the `setState` method after the `await` calls.