### PR TITLE
option to add http headers when retrieving pdf document from url

### DIFF
--- a/lib/src/document.dart
+++ b/lib/src/document.dart
@@ -33,9 +33,9 @@ class PDFDocument {
   /// Load a PDF File from a given URL.
   /// File is saved in cache
   ///
-  static Future<PDFDocument> fromURL(String url) async {
+  static Future<PDFDocument> fromURL(String url, {Map<String, String> headers}) async {
     // Download into cache
-    File f = await DefaultCacheManager().getSingleFile(url);
+    File f = await DefaultCacheManager().getSingleFile(url, headers: headers);
     PDFDocument document = PDFDocument();
     document._filePath = f.path;
     try {


### PR DESCRIPTION
This will allow users to add http headers:

`PDFDocument doc = await PDFDocument.fromURL('http://www.africau.edu/images/default/sample.pdf', headers: { 'header-name': 'header-value' });`
