### PR TITLE
Hide BottomNavigationBar when document have just one page.

### DIFF
--- a/lib/src/viewer.dart
+++ b/lib/src/viewer.dart
@@ -140,64 +140,65 @@ class _PDFViewerState extends State<PDFViewer> {
             )
           : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-      bottomNavigationBar: (widget.showNavigation || widget.document.count > 1)
-          ? BottomAppBar(
-              child: new Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Expanded(
-                    child: IconButton(
-                      icon: Icon(Icons.first_page),
-                      tooltip: widget.tooltip.first,
-                      onPressed: () {
+      bottomNavigationBar: Visibility(
+          visible: (widget.showNavigation && widget.document.count > 1),
+          child: BottomAppBar(
+            child: new Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Expanded(
+                  child: IconButton(
+                    icon: Icon(Icons.first_page),
+                    tooltip: widget.tooltip.first,
+                    onPressed: () {
+                      _pageNumber = 1;
+                      _loadPage();
+                    },
+                  ),
+                ),
+                Expanded(
+                  child: IconButton(
+                    icon: Icon(Icons.chevron_left),
+                    tooltip: widget.tooltip.previous,
+                    onPressed: () {
+                      _pageNumber--;
+                      if (1 > _pageNumber) {
                         _pageNumber = 1;
-                        _loadPage();
-                      },
-                    ),
+                      }
+                      _loadPage();
+                    },
                   ),
-                  Expanded(
-                    child: IconButton(
-                      icon: Icon(Icons.chevron_left),
-                      tooltip: widget.tooltip.previous,
-                      onPressed: () {
-                        _pageNumber--;
-                        if (1 > _pageNumber) {
-                          _pageNumber = 1;
-                        }
-                        _loadPage();
-                      },
-                    ),
-                  ),
-                  widget.showPicker
-                      ? Expanded(child: Text(''))
-                      : SizedBox(width: 1),
-                  Expanded(
-                    child: IconButton(
-                      icon: Icon(Icons.chevron_right),
-                      tooltip: widget.tooltip.next,
-                      onPressed: () {
-                        _pageNumber++;
-                        if (widget.document.count < _pageNumber) {
-                          _pageNumber = widget.document.count;
-                        }
-                        _loadPage();
-                      },
-                    ),
-                  ),
-                  Expanded(
-                    child: IconButton(
-                      icon: Icon(Icons.last_page),
-                      tooltip: widget.tooltip.last,
-                      onPressed: () {
+                ),
+                widget.showPicker
+                    ? Expanded(child: Text(''))
+                    : SizedBox(width: 1),
+                Expanded(
+                  child: IconButton(
+                    icon: Icon(Icons.chevron_right),
+                    tooltip: widget.tooltip.next,
+                    onPressed: () {
+                      _pageNumber++;
+                      if (widget.document.count < _pageNumber) {
                         _pageNumber = widget.document.count;
-                        _loadPage();
-                      },
-                    ),
+                      }
+                      _loadPage();
+                    },
                   ),
-                ],
-              ),
-            )
-          : Container(),
+                ),
+                Expanded(
+                  child: IconButton(
+                    icon: Icon(Icons.last_page),
+                    tooltip: widget.tooltip.last,
+                    onPressed: () {
+                      _pageNumber = widget.document.count;
+                      _loadPage();
+                    },
+                  ),
+                ),
+              ],
+            ),
+          )
+      ),
     );
   }
 }


### PR DESCRIPTION
I Had some problemens when i tried to use a pdf with just one page.
I want to hide BottomNavigationBar, but it's impossible. 

Code with error:

`void main() => runApp(MyApp());

class MyApp extends StatefulWidget {
  @override
  _MyAppState createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  bool _isLoading = true;
  PDFDocument document;

  @override
  void initState() {
    super.initState();
    loadDocument();
  }

  loadDocument() async {
    document = await PDFDocument.fromURL('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
    setState(() => _isLoading = false);
  }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        appBar: AppBar(
          title: const Text('FlutterPluginPDFViewer'),
        ),
        body: Center(
            child: _isLoading
                ? Center(child: CircularProgressIndicator())
                : PDFViewer(document: document, showNavigation: false,)),
      ),
    );
  }
}
`